### PR TITLE
Fix multiplication and division in MathExpr

### DIFF
--- a/CEasyUO.csproj
+++ b/CEasyUO.csproj
@@ -35,6 +35,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>icons\easyuo2.ico</ApplicationIcon>

--- a/Scripting/AST.cs
+++ b/Scripting/AST.cs
@@ -695,11 +695,11 @@ namespace CEasyUO
                     break;
                 case Symbol.mul:
                     if(leftExpr is IntLiteral || rightExpr is IntLiteral)
-                        return (int)leftExpr.GetValueInt() - (int)rightExpr.GetValueInt();
+                        return (int)leftExpr.GetValueInt() * (int)rightExpr.GetValueInt();
                     break;
                 case Symbol.div:
-                    if(leftExpr is IntLiteral || rightExpr is IntLiteral)
-                        return (int)leftExpr.GetValueInt() - (int)rightExpr.GetValueInt();
+                    if(leftExpr is IntLiteral || rightExpr is IntLiteral && rightExpr.GetValueInt() != 0)
+                        return (int)leftExpr.GetValueInt() / (int)rightExpr.GetValueInt();
                     break;
                 case Symbol.Concat:
                     return leftExpr.GetValue().ToString() + rightExpr.GetValue().ToString();


### PR DESCRIPTION
## Summary
- correct `Symbol.mul` and `Symbol.div` cases to perform multiplication and division
- enable unsafe code for Release builds

## Testing
- `xbuild CEasyUO.csproj /p:Configuration=Release`
- `xbuild CEasyUO.csproj /p:Configuration=Debug`

------
https://chatgpt.com/codex/tasks/task_e_684599beb9b08332ad444b20d30356f7